### PR TITLE
Lint .mjs (JS modules) by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note: the `fix` option is only supported from `1.3.4`
 ### shouldLint
 
 - Type: `(path: string) => boolean`
-- Default: `(path) => path.match(/\/src\/.*\.[jt]sx?$/)`
+- Default: `(path) => path.match(/\/src\/[^?]*\.(vue|m?[jt]sx?)$/)`
 
 ### formatter
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { normalizePath } = require("vite");
 module.exports = function eslintPlugin(options = {}) {
   const {
     eslintOptions = {},
-    shouldLint = (path) => path.match(/\/src\/.*\.m?[jt]sx?$/),
+    shouldLint = (path) => path.match(/\/src\/[^?]*\.(vue|m?[jt]sx?)$/),
     formatter,
   } = options;
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { normalizePath } = require("vite");
 module.exports = function eslintPlugin(options = {}) {
   const {
     eslintOptions = {},
-    shouldLint = (path) => path.match(/\/src\/.*\.[jt]sx?$/),
+    shouldLint = (path) => path.match(/\/src\/.*\.m?[jt]sx?$/),
     formatter,
   } = options;
 


### PR DESCRIPTION
Extremely small suggestion that comes with the PR! I think that ESLint should be linting .mjs files by default as well as the JS, TS, and React files it does currently.